### PR TITLE
Fix for light on nVidia GPUs

### DIFF
--- a/src/Light.cpp
+++ b/src/Light.cpp
@@ -84,15 +84,6 @@ glm::vec3 Light::get_pos()
     return this->position;
 }
 
-void Light::upload_pos()
-{
-    glUseProgram(shader_program);
-    const char* name = ("lights[" + std::to_string(this->id) + "].position").c_str();
-    GLuint pos_loc = glGetUniformLocation(shader_program, name);
-    glUniform3fv(pos_loc, 1, glm::value_ptr(this->position));
-    glUseProgram(0);
-}
-
 // ------------
 // Changes color of light
 

--- a/src/Light.hpp
+++ b/src/Light.hpp
@@ -28,7 +28,6 @@ public:
     void set_color(glm::vec3 color);
     glm::vec3 get_pos();
     void move_to(glm::vec3 world_coord); // does not upload data
-    void upload_pos();
 
 private:
     unsigned int id;

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -151,7 +151,7 @@ void Model::move_to(glm::vec3 world_coord) {
     for (auto light_container : this->attached_lightsources) {
         glm::vec3 new_pos = glm::vec3(m2w_matrix * glm::vec4(light_container.relative_pos, 1.f));
         light_container.light->move_to(new_pos);
-        light_container.light->upload_pos();
+        light_container.light->upload();
     }
 }
 
@@ -168,7 +168,7 @@ void Model::rotate(glm::vec3 axis, float angle) {
     for (auto light_container : this->attached_lightsources) {
         glm::vec3 new_pos = glm::vec3(m2w_matrix * glm::vec4(light_container.relative_pos, 1.f));
         light_container.light->move_to(new_pos);
-        light_container.light->upload_pos();
+        light_container.light->upload();
     }
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -85,7 +85,7 @@ void Renderer::set_mode(render_mode mode)
         break;
     case DEFERRED_MODE:
         Light::shader_program = shaders[DEFERRED];
-        glClearColor(0, 0, 0, 1.0);
+        clear_ssao();
         break;
     case POSITION_MODE:
         Light::shader_program = shaders[DEFERRED];


### PR DESCRIPTION
Removed Light::upload_pos since nVidia GPUs does not seem to allow uploading one element of a vector to a uniform. Instead use the function Light::upload() when changing a light. 
